### PR TITLE
added wheel build for linux arm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,14 @@ jobs:
           manylinux: auto
           args: -i python${{ matrix.python-version }} --release --strip
 
+      - name: Build Wheels - Linux ARM
+        if: matrix.os == 'ubuntu-latest'
+        uses: messense/maturin-action@v1
+        with:
+          manylinux: auto
+          target: aarch64-unknown-linux-gnu
+          args: -i python${{ matrix.python-version }} --release --strip
+
       - name: Build Wheels - MacOS
         if: matrix.os == 'macos-latest'
         uses: messense/maturin-action@v1


### PR DESCRIPTION
There are no wheels when using on an M1-based (arm) mac inside Docker.
`uname -a` returns
```
root@6c6e7283e74d:/app# uname -a
Linux 6c6e7283e74d 5.10.47-linuxkit #1 SMP PREEMPT Sat Jul 3 21:50:16 UTC 2021 aarch64 GNU/Linux
```