### PR TITLE
Replace `closed` with `inclusive` in pd.date_range

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ xirr(pd.Series(amounts, index=pd.to_datetime(dates)))
 
 # bonus: apply xirr to a DataFrame with DatetimeIndex:
 df = pd.DataFrame(
-    index=pd.date_range("2021", "2022", freq="MS", closed="left"),
+    index=pd.date_range("2021", "2022", freq="MS", inclusive="left"),
     data={
         "one": [-100] + [20] * 11,
         "two": [-80] + [19] * 11,


### PR DESCRIPTION
Parameter `closed` is deprecated in `pandas` since version 1.4.1 in favour of `inclusive`.