### PR TITLE
Updates for Maturin 1.8: add a version key in the project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "pyxirr"
+version = "0.10.6"
 description-content-type = "text/markdown; charset=UTF-8; variant=GFM"
 requires-python = ">=3.7,<3.14"
 classifiers = [


### PR DESCRIPTION
## Description

Through https://github.com/PyO3/maturin/pull/2391 via the recently released https://github.com/PyO3/maturin/releases/tag/v1.8.0, we've been seeing failing builds for PyXIRR in Pyodide ([logs](https://app.circleci.com/pipelines/github/pyodide/pyodide/8372/workflows/9474e6a9-6a93-499d-8a66-da88da493e16/jobs/122581)), which was added in https://github.com/pyodide/pyodide/pull/4513.

I've opened this PR since I saw that you were listed as a maintainer for [PyXIRR's recipe in Pyodide](https://github.com/pyodide/pyodide/blob/519897c8fb10fd4f11682bb3ef363e8a16f9e4f5/packages/pyxirr/meta.yaml#L18-L20), and I shall be applying this PR as a patch to fix the failing build. If you'd like me to set it as a dynamic attribute or something else of your liking, please let me know. Thank you!

## Additional context

- List of changes for Maturin 1.8.0: https://github.com/PyO3/maturin/blob/main/Changelog.md#180